### PR TITLE
Fix location configuration in prod NGINX

### DIFF
--- a/config/nginx/nginx_prod.conf
+++ b/config/nginx/nginx_prod.conf
@@ -38,7 +38,7 @@ http {
       }
 
       # The last-updated resource will be cached for 5 minutes max.
-      location /api/v1/spider-results/last-updated/ {
+      location = /api/v1/spider-results/last-updated/ {
         proxy_pass http://api:5000/api/v1/spider-results/last-updated/;
         proxy_cache api;
         proxy_cache_background_update on;
@@ -51,7 +51,7 @@ http {
       }
 
       # The big results are stored for a long time
-      location /api/v1/spider-results/table/ {
+      location = /api/v1/spider-results/table/ {
         proxy_pass http://api:5000;
         proxy_cache api;
         proxy_cache_background_update on;
@@ -109,8 +109,12 @@ http {
         proxy_ignore_headers    Set-Cookie;
       }
 
-      location ~ ^/(?!(api|screenshots)) {
+      location /sites/ {
         try_files $uri $uri/ /index.html;
+      }
+
+      location = / {
+        try_files $uri /index.html;
       }
 
     }


### PR DESCRIPTION
This solves the problems that screenshots could not be loaded in production (when displayed outside the webapp context), because the wrong `location` block applied.