### PR TITLE
Search improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "html-webpack-plugin": "2.29.0",
     "jest": "20.0.4",
     "lodash": "^4.17.11",
-    "lunr": "^2.3.4",
+    "lunr": "^2.3.6",
     "merge": "1.2.1",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",

--- a/src/SitesSearch.js
+++ b/src/SitesSearch.js
@@ -139,7 +139,7 @@ class SearchField extends Component {
     this.setState({value: q});
 
     if (q.length > minTermLength && q !== this.state.lastQuery) {
-      var searchResult = this.props.searchIndex.search(q + "*");
+      var searchResult = this.props.searchIndex.search(q.trim() + "*");
       this.setState({
         lastQuery: q,
         hits: searchResult.length,

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,9 @@ class App extends React.Component {
   createSearchIndex = (sites) => {
     var tu = this.tokenizeURL;
     let searchIndex = lunr(function() {
+      this.pipeline.remove(lunr.stemmer)
+      this.searchPipeline.remove(lunr.stemmer)
+
       this.field('url');
       this.field('state');
       this.field('district');

--- a/src/index.js
+++ b/src/index.js
@@ -62,17 +62,22 @@ class App extends React.Component {
       })
   }
 
+  tokenizeURL = (url) => {
+    return url.replace(/[:.-/]+/gi, ' ');
+  }
+
   createSearchIndex = (sites) => {
+    var tu = this.tokenizeURL;
     let searchIndex = lunr(function() {
       this.field('url');
       this.field('state');
       this.field('district');
       this.field('city');
-    
+
       for (var site of sites) {
         this.add({
           "id": site.input_url,
-          "url": [site.input_url],
+          "url": tu(site.input_url),
           "state": site.meta.state,
           "district": site.meta.district,
           "city": site.meta.city,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4937,10 +4937,10 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lunr@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.4.tgz#ecc045a48a6ecd96f1bb812fff70b33731753412"
-  integrity sha512-o0D846XyAlPkBMVK3ZgVYrLHho3yhJHgpm0BxZT3dGdFa+tpQwdQdI4EUihsmWz8Fr3aaux4eahO9Ih7Z3e1eQ==
+lunr@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.6.tgz#f278beee7ffd56ad86e6e478ce02ab2b98c78dd5"
+  integrity sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==
 
 make-dir@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
- allow to search URL substrings ('gruene', 'www')
- don't stem words, to allow search for `karlsruhe` and others
- Remove trailing space from query term
- update lunr to the latest version