### PR TITLE
Neues Kriterium: Keine Third Party Cookies

### DIFF
--- a/src/SearchResultItem.js
+++ b/src/SearchResultItem.js
@@ -21,7 +21,7 @@ class SearchResultItem extends Component {
             <URLField url={this.props.site._source.url} link={false} />
           </div>
           <div className='col-3 col-sm-2 col-md-2 d-flex'>
-            <ScoreField score={this.props.site._source.score} maxScore={15} />
+            <ScoreField score={this.props.site._source.score} maxScore={16} />
           </div>
         </div>
       </Link>

--- a/src/SiteDetailsPage.js
+++ b/src/SiteDetailsPage.js
@@ -115,6 +115,11 @@ class SiteDetailsPage extends Component {
         data: this.state.site.rating.FEEDS,
       },
       {
+        criterium: 'NO_THIRD_PARTY_COOKIES',
+        component: <CookiesField key='cookies' data={this.state.site.rating.NO_THIRD_PARTY_COOKIES} />,
+        data: this.state.site.rating.NO_THIRD_PARTY_COOKIES,
+      },
+      {
         criterium: 'NO_SCRIPT_ERRORS',
         component: <ScriptErrorsField key='scripterrors' data={this.state.site.rating.NO_SCRIPT_ERRORS} />,
         data: this.state.site.rating.NO_SCRIPT_ERRORS,
@@ -183,7 +188,7 @@ class SiteDetailsPage extends Component {
 
           <hr />
 
-          <ScoreComparisonWidget sitesCount={this.props.sitesCount} thisSite={this.state.site} maxScore={15} />
+          <ScoreComparisonWidget sitesCount={this.props.sitesCount} thisSite={this.state.site} maxScore={16} />
 
           {
             this.state.site.rating.SITE_REACHABLE.value ?
@@ -364,6 +369,15 @@ class FeedField extends Component {
   }
 }
 
+class CookiesField extends Component {
+  render() {
+    if (this.props.data.value) {
+      return <CriteriumField keyProp='feed' type='positive' title='Es werden keine Third Party Cookies gesetzt' />;
+    }
+    return <CriteriumField keyProp='feed' type='negative' title='Beim Laden der Site werden Third Party Cookies gesetzt' />;
+  }
+}
+
 class FontField extends Component {
   render() {
     let font = 'Arvo';
@@ -460,7 +474,6 @@ class Screenshots extends Component {
 
       axios.get(`/api/v1/screenshots/site?url=${encodeURIComponent(url)}`)
         .then((response) => {
-          console.debug(response.data);
           // Success
           let screenshots = null;
 


### PR DESCRIPTION
Fixes https://github.com/netzbegruenung/green-spider/issues/10

Mit dieser Änderung wird ein neues Kriterium eingeführt: Werden auf der Site Cookies von Dritten (Third Party Cookies) gesetzt? Falls das nicht der Fall ist, wird ein Punkt gegeben.

Damit soll das Bewusstsein dafür geschärft werden, dass Third Party Cookies einen Eingriff in das Recht auf informationelle Selbstbestimmung der Webnutzer*innen darstellt. Das gilt inbesondere Dann, wenn diese Cookies gesetzt werden, _bevor_ der/die Nutzer*in eine audrückliche EInwilligung gegeben hat.

Green Spider interagiert nicht mit eventuell angezeigten Bannern etc. für die Datenschutz-Einwilligung. Wenn Green Spider Third Party Cookies erfasst, dann werden diese somit sämtlich _ohne_ besondere Einwilligung durch die Nutzer*innen gesetzt.