### PR TITLE
Mehr Details zu HTTPS-Problemen anzeigen

### DIFF
--- a/src/ui/criterium_fields/HTTPSField.js
+++ b/src/ui/criterium_fields/HTTPSField.js
@@ -25,6 +25,10 @@ class HTTPSField extends Component {
 
 class HTTPSProblemsTable extends Component {
   render() {
+    if (typeof this.props.details === 'undefined') {
+      return undefined;
+    }
+    
     return <div>
       <p>Sämtliche auflösbaren Hostnamen bzw. Domains sollten per HTTPS erreichbar sein, und sei es nur zum Zweck einer Weiterleitung. Die folgende(n) URL(s) wurden überprüft:</p>
       <ul>

--- a/src/ui/criterium_fields/HTTPSField.js
+++ b/src/ui/criterium_fields/HTTPSField.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import CriteriumField from './CriteriumField';
+import PropTypes from 'prop-types';
+
 
 class HTTPSField extends Component {
   render() {
@@ -8,16 +10,51 @@ class HTTPSField extends Component {
     }
 
     return <CriteriumField keyProp='https' type='negative' title='Die Site sollte über HTTPS erreichbar sein'>
+      <HTTPSProblemsTable details={this.props.details} />
       <p>Per TLS verschlüsselte HTTP-Verbindungen schützen Nutzer*innen vor der Preisgabe privater Informationen.
         Entsprechend gehört HTTPS für immer mehr Nutzer*innen bei einem vertrauenswürdigen Webangebot zu den
         Pflicht-Kriterien. Auch viele Unternehmen, darunter beispielsweise Google, haben inzwischen die HTTPS-Verbindung
         zum Standard erklärt. Seiten, die nicht per HTTPS erreichbar sind, werden entsprechend von Google im
         Suchergebnis schlechter platziert.</p>
-      <p>Inzwischen gibt es TLS-Zertifikate für Verschlüsselte Server-Kommunikation auch kostenlos, z. B. von
+      <p>Inzwischen gibt es TLS-Zertifikate für verschlüsselte Server-Kommunikation auch kostenlos, z. B. von
         <a href='https://letsencrypt.org/getting-started/' target='_blank' rel='noopener noreferrer'>Let's Encrypt</a>.</p>
       <p>Lesetipp: <a href='https://webmasters.googleblog.com/2014/08/https-as-ranking-signal.html' target='_blank' rel='noopener noreferrer'>HTTPS as a ranking signal </a></p>
     </CriteriumField>;
   }
 }
+
+class HTTPSProblemsTable extends Component {
+  render() {
+    return <div>
+      <p>Sämtliche auflösbaren Hostnamen bzw. Domains sollten per HTTPS erreichbar sein, und sei es nur zum Zweck einer Weiterleitung. Die folgende(n) URL(s) wurden überprüft:</p>
+      <ul>
+          {
+            Object.entries(this.props.details).map((item) => {
+              if (item[0].startsWith('https:')) {
+                return <li key={item[0]}>
+                    <p>
+                      <code>{item[0]}</code>
+                      {
+                        item[1].exception === null ? <span className='badge badge-primary'>OK</span> : <span className='badge badge-warning'>Fehler</span>
+                      }
+                    </p>
+                    {
+                      item[1].exception !== null ? <p>Fehlermeldung: <code>{item[1].exception.message}</code></p> : undefined
+                    }
+                  </li>;
+              } else {
+                return undefined;
+              }
+            })
+          }
+      </ul>
+    </div>;
+  }
+}
+
+HTTPSField.propTypes = {
+  data: PropTypes.object,    // HTTPS rating information
+  details: PropTypes.object, // url_reachability check details
+};
 
 export default HTTPSField;

--- a/src/ui/criterium_fields/HTTPSField.js
+++ b/src/ui/criterium_fields/HTTPSField.js
@@ -26,9 +26,9 @@ class HTTPSField extends Component {
 class HTTPSProblemsTable extends Component {
   render() {
     if (typeof this.props.details === 'undefined') {
-      return undefined;
+      return null;
     }
-    
+
     return <div>
       <p>Sämtliche auflösbaren Hostnamen bzw. Domains sollten per HTTPS erreichbar sein, und sei es nur zum Zweck einer Weiterleitung. Die folgende(n) URL(s) wurden überprüft:</p>
       <ul>


### PR DESCRIPTION
Bislang wurden HTTPS-Probleme nicht einzeln angezeigt bzw. erläutert.

Dieser PR fügt im Fall von Problemen eine Auflistung aller geprüften HTTPS-URLs ein. Damit sollten Nutzer*innen ein besseres Verständnis davon bekommen, was zu tun ist.

### Vorschau

![image](https://user-images.githubusercontent.com/273727/68810205-e5832300-066d-11ea-8395-2e2a19e4708c.png)


### TODO

- [ ] Dafür sorgen, dass Details angezeigt werden, nachdem sie geladen wurden